### PR TITLE
swapped console.log for debug library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # gds-wrapper
 A shallow wrapper to use the IBM Graph - Prototype!
+
+
+## Debugging
+
+In order to see debugging messages for every API call that is made, set the environment variable `DEBUG` before running your application that uses the *gds-wrapper* library e.g.
+
+```sh
+export DEBUG=gds-wrapper
+node app.js
+```
+
+or 
+
+```sh
+DEBUG=gds-wrapper node app.js
+```
+

--- a/lib/gds.js
+++ b/lib/gds.js
@@ -16,6 +16,7 @@
 var assert  = require('assert');
 var _       = require('underscore');
 var request = require('request');
+var debug = require('debug')('gds-wrapper');
 
 // Global
 function gds(config) {
@@ -97,7 +98,7 @@ gds.prototype.apiCall = function (opts, callback) {
   }
 
   // Debug Opts
-  if (opts.debug) { console.log(opts); }
+  if (opts.debug) { debug(opts); }
 
   return request(opts, function (error, response, body) {
     var returnObject = {
@@ -106,7 +107,7 @@ gds.prototype.apiCall = function (opts, callback) {
       body: body,
     };
 
-    if (opts.debug) { console.log(returnObject); }
+    if (opts.debug) { debug(returnObject); }
 
     if (!callback) {
       return returnObject;

--- a/lib/gds.js
+++ b/lib/gds.js
@@ -74,10 +74,6 @@ gds.prototype.apiCall = function (opts, callback) {
 
   var config = this.config;
 
-  // Debug
-  opts.debug = (config.debug) ? config.debug :
-    ((!opts.debug) ? false : opts.debug);
-
   // Force the URL
   if (typeof opts.url === 'object') {
     opts.url = opts.url.baseURL + opts.url.url;
@@ -98,7 +94,7 @@ gds.prototype.apiCall = function (opts, callback) {
   }
 
   // Debug Opts
-  if (opts.debug) { debug(opts); }
+  debug(opts);
 
   return request(opts, function (error, response, body) {
     var returnObject = {
@@ -107,7 +103,7 @@ gds.prototype.apiCall = function (opts, callback) {
       body: body,
     };
 
-    if (opts.debug) { debug(returnObject); }
+    debug(returnObject);
 
     if (!callback) {
       return returnObject;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/ibm-cds-labs/gds-wrapper",
   "dependencies": {
+    "debug": "^2.2.0",
     "request": "~2.67.0",
     "underscore": "~1.8.3"
   },


### PR DESCRIPTION
The debug library is a tiny dependency but means devs can switch on debugging at runtime with a simple environment variable. e.g. if you're using this library & nodejs-cloudant, you can switch on debugging with

```
DEBUG=nano,gds-wrapper node app.js
```

It's very neat.